### PR TITLE
Fix usage Yasat no root

### DIFF
--- a/common
+++ b/common
@@ -215,7 +215,7 @@ Display()
 	if [ -z "${ADVICE}" -o "${ADVICE}" = 'NONE' ] ;then
 		ADVICEVALUE=''
 	else
-		ADVICEVALUE="`grep ${ADVICE}= ${YASAT_ROOT}/yasat.advices | cut -d\= -f2-`"
+		ADVICEVALUE="`grep ${ADVICE}= ${YASAT_HOME}/yasat.advices | cut -d\= -f2-`"
 		if [ -z "$ADVICEVALUE" ] ;then
 			Display --indent 2 --text "BUG ADVICEVALUE is empty for ${ADVICE}" --result WARNING --color RED --advice YASAT_BUG
 		fi

--- a/common
+++ b/common
@@ -3442,7 +3442,7 @@ setup_yasat_defaults() {
 ################################################################################
 ################################################################################
 setup_yasat_tmpdir() {
-	TEMPYASATDIR="`echo ~/.yasat/`"
+	TEMPYASATDIR="`echo ~/.yasat`"
 	mkdir -p $TEMPYASATDIR
 	if [ $? -ne 0 ];then
 		TEMPYASATDIR='/tmp/yasat'

--- a/yasat
+++ b/yasat
@@ -37,9 +37,9 @@ POSSIBLE_APACHE_BIN="/usr/sbin/apache2 /usr/local/sbin/httpd /usr/local/sbin/apa
 DEBUG=0
 
 # the .yasat directory in the home of the user running yasat
-YASAT_HOMEDIR="$HOME/.yasat/"
+YASAT_HOMEDIR="$HOME/.yasat"
 if [ -z "$YASAT_HOMEDIR" ];then
-	YASAT_HOMEDIR="`echo ~/.yasat/`"
+	YASAT_HOMEDIR="`echo ~/.yasat`"
 fi
 HTML_OUTPUT=""
 ADVICELANG="EN"
@@ -505,7 +505,7 @@ fi
 
 if [ -d "$PLUGINS_REP" ] ; then
 	LISTE_ADVICE="`ls $PLUGINS_REP/*.advice`"
-	cat $LISTE_ADVICE | grep $ADVICELANG > ${YASAT_ROOT}/yasat.advices
+	cat $LISTE_ADVICE | grep $ADVICELANG > ${YASAT_HOMEDIR}/yasat.advices
 
 	if [ -z "$ONEPLUGIN" ] ; then
 		Debug "Analyse de $PLUGINS_REP"


### PR DESCRIPTION
yasat.advice will be written in the HOME folder as occurs for all other files. In this way, the user can use Yasat also with no root privileges.

Furthermore, fixed some `/` typo.